### PR TITLE
Embedded notes tagged #dekunobou on ActivityPub

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -30,5 +30,15 @@
         <script src="scripts/main.js"></script>
         <button onclick="tweet()">Tweet</button>
         <a href="https://misskeyshare.link/share.html?text=" onclick="window.open(this.href+encodeURIComponent(misskey_note()), '', 'width=500,height=400'); return false;"><img src="https://jiskey.dev/files/1dcedb0b-8f9a-439e-a81a-fa623ce7eed2" width="80" height="20"></a>
+        <p>
+            <iframe
+                src="https://jiskey.dev/embed/tags/dekunobou?maxHeight=400"
+                data-misskey-embed-id="v1_dekunobou-timeline"
+                loading="lazy"
+                referrerpolicy="strict-origin-when-cross-origin"
+                style="border: none; width: 100%; max-width: 500px; height: 300px; color-scheme: light dark;"
+            ></iframe>
+            <script defer src="https://jiskey.dev/embed.js"></script>
+        </p>
     </body>
 </html>


### PR DESCRIPTION
ActivityPub上で#dekunobouのタグがついたノートを埋め込みで表示するようにした。
ただしhttps://jiskey.dev で観測できるノートのみなのでjiskeyと連合していないサーバーのノートは見れない。
srcをhttps://misskey.io に変えてもいいかもしれない